### PR TITLE
Correct QCG link

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ conda install crest
   DOI: [10.1002/jcc.24922](https://dx.doi.org/10.1002/jcc.24922)
 
 5. S. Spicher, C. Plett, P. Pracht, A. Hansen, S. Grimme,  *J. Chem. Theory Comput.*, **2022**,
-  *18*, 3174-3189. DOI: [10.1021/acs.jctc.2c00239](https://dx.doi.org/10.1002/jcc.24922)
+  *18*, 3174-3189. DOI: [10.1021/acs.jctc.2c00239](https://dx.doi.org/10.1021/acs.jctc.2c00239)
 
 ## License
 


### PR DESCRIPTION
The link for the QCG citation was wrong  and is now corrected.